### PR TITLE
Change from Daimler AG to Mercedes-Benz AG

### DIFF
--- a/content/membership/members/daimler.md
+++ b/content/membership/members/daimler.md
@@ -1,5 +1,5 @@
 ---
-title: "Daimler AG"
+title: "Mercedes-Benz AG"
 date: 2019-03-14T05:10:00-00:00
 logo: "/membership/members/logo/daimler.png"
 website: "https://www.daimler.com"


### PR DESCRIPTION
Change from Daimler AG to Mercedes-Benz AG as requested by member